### PR TITLE
fix: Corregir tipo de datos en EventGridPublisher

### DIFF
--- a/src/main/java/com/agranelos/inventario/events/EventGridPublisher.java
+++ b/src/main/java/com/agranelos/inventario/events/EventGridPublisher.java
@@ -1,6 +1,7 @@
 package com.agranelos.inventario.events;
 
 import com.azure.core.credential.AzureKeyCredential;
+import com.azure.core.util.BinaryData;
 import com.azure.messaging.eventgrid.EventGridEvent;
 import com.azure.messaging.eventgrid.EventGridPublisherClient;
 import com.azure.messaging.eventgrid.EventGridPublisherClientBuilder;
@@ -64,7 +65,7 @@ public class EventGridPublisher {
             EventGridEvent event = new EventGridEvent(
                 String.format("/productos/%d", eventData.getProductoId()),
                 eventType.getValue(),
-                objectMapper.writeValueAsString(eventData),
+                BinaryData.fromString(objectMapper.writeValueAsString(eventData)),
                 "1.0"
             );
             event.setEventTime(OffsetDateTime.now());
@@ -95,7 +96,7 @@ public class EventGridPublisher {
             EventGridEvent event = new EventGridEvent(
                 String.format("/bodegas/%d", eventData.getBodegaId()),
                 eventType.getValue(),
-                objectMapper.writeValueAsString(eventData),
+                BinaryData.fromString(objectMapper.writeValueAsString(eventData)),
                 "1.0"
             );
             event.setEventTime(OffsetDateTime.now());


### PR DESCRIPTION
- Agregar import de BinaryData
- Envolver JSON strings con BinaryData.fromString()
- Corregir línea 67: publishProductoEvent
- Corregir línea 98: publishBodegaEvent

Esto resuelve el error de tipo mismatch donde EventGridEvent espera BinaryData en lugar de String para el campo de datos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved event publishing by wrapping payloads in a binary format, enhancing compatibility and reliability when sending product and warehouse notifications to the event system.
  * Reduces serialization edge cases and should make deliveries more consistent across varied payloads.
  * No changes to user workflows or public APIs; existing logging and error handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->