### PR TITLE
fix: Agregar variables de entorno DB al workflow CI

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -9,6 +9,12 @@ on:
 
 env:
   JAVA_VERSION: '11'
+  DB_HOST: '50.19.86.166'
+  DB_PORT: '5432'
+  DB_NAME: 'inventario_agranelos'
+  DB_USER: 'postgres'
+  DB_PASSWORD: 'test-password'
+  DB_SSL_MODE: 'disable'
 
 jobs:
   build:


### PR DESCRIPTION
- Agregar DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD
- Workflow ya usa -DskipTests (correcto)
- Resuelve error de variable DB_HOST no encontrada

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration configuration to include database connection settings as environment variables.
  * No changes to application features or behavior; end users are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->