### PR TITLE
security: Usar GitHub Secrets para credenciales DB

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -9,16 +9,18 @@ on:
 
 env:
   JAVA_VERSION: '11'
-  DB_HOST: '50.19.86.166'
-  DB_PORT: '5432'
-  DB_NAME: 'inventario_agranelos'
-  DB_USER: 'postgres'
-  DB_PASSWORD: 'test-password'
-  DB_SSL_MODE: 'disable'
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    
+    env:
+      DB_HOST: ${{ secrets.DB_HOST }}
+      DB_PORT: ${{ secrets.DB_PORT }}
+      DB_NAME: ${{ secrets.DB_NAME }}
+      DB_USER: ${{ secrets.DB_USER }}
+      DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+      DB_SSL_MODE: 'disable'
     
     steps:
     - name: '📥 Checkout repository'


### PR DESCRIPTION
- Remover credenciales hardcoded del workflow
- Usar secrets.DB_HOST, secrets.DB_PORT, etc.
- DB_SSL_MODE queda hardcoded (no es sensible)

IMPORTANTE: Configurar estos secrets en GitHub:
- Settings > Secrets > Actions > New repository secret
- DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated CI to source database configuration per job from secure repository secrets, improving security and isolation in test builds.
  - Removed globally defined environment variables to reduce cross-job leakage risk and align with best practices.
  - Build and test steps remain unchanged; this is a behind-the-scenes improvement aimed at strengthening reliability without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->